### PR TITLE
Add a "Show Channel Name" toggle and size guide logos to the rail slot

### DIFF
--- a/app/src/main/java/com/aeriotv/android/core/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/aeriotv/android/core/preferences/AppPreferences.kt
@@ -133,6 +133,21 @@ class AppPreferences @Inject constructor(
     }
 
     /**
+     * GH #73. When off, the Live TV list and the Guide rail hide the channel
+     * NAME, leaving the logo (and number) to identify the row. Default ON.
+     *
+     * The complement of the logos toggle: a provider whose logos are clear
+     * artwork gains rail width for the programme grid by dropping a name that
+     * only repeats what the logo already says. Turning all three off is allowed
+     * -- the row keeps its EPG content and stays selectable -- so nothing here
+     * force-enables a fallback the user explicitly switched off.
+     */
+    val showChannelNames: Flow<Boolean> = store.data.map { it[KEY_SHOW_CHANNEL_NAMES] ?: true }
+    suspend fun setShowChannelNames(value: Boolean) {
+        store.edit { it[KEY_SHOW_CHANNEL_NAMES] = value }
+    }
+
+    /**
      * Whether the EPG program badges (LIVE / NEW / PREMIERE / FINALE / REPEAT +
      * season/episode pill) render in the guide, channel list, and info sheet.
      * Default ON. Stored + Drive-synced PER DEVICE TYPE (a separate value for TV
@@ -1367,6 +1382,7 @@ class AppPreferences @Inject constructor(
         val KEY_USE_CUSTOM_ACCENT = booleanPreferencesKey("use_custom_accent")
         val KEY_SHOW_CHANNEL_LOGOS = booleanPreferencesKey("ui_show_channel_logos")
         val KEY_SHOW_CHANNEL_NUMBERS = booleanPreferencesKey("ui_show_channel_numbers")
+        val KEY_SHOW_CHANNEL_NAMES = booleanPreferencesKey("ui_show_channel_names")
         val KEY_SHOW_EPG_BADGES_TV = booleanPreferencesKey("ui_show_epg_badges_tv")
         val KEY_SHOW_EPG_BADGES_MOBILE = booleanPreferencesKey("ui_show_epg_badges_mobile")
         val KEY_PLAYER_ASPECT_MODE = stringPreferencesKey("player_aspect_mode")

--- a/app/src/main/java/com/aeriotv/android/feature/channels/ChannelListScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/channels/ChannelListScreen.kt
@@ -163,6 +163,7 @@ fun ChannelListScreen(
     val hiddenGroups by settingsVm.hiddenGroups.collectAsStateWithLifecycle(initialValue = emptySet())
     val showChannelLogos by settingsVm.showChannelLogos.collectAsStateWithLifecycle(initialValue = true)
     val showChannelNumbers by settingsVm.showChannelNumbers.collectAsStateWithLifecycle(initialValue = true)
+    val showChannelNames by settingsVm.showChannelNames.collectAsStateWithLifecycle(initialValue = true)
     val groupSortModeRaw by settingsVm.groupSortMode.collectAsStateWithLifecycle(initialValue = "Default")
     val groupOrder by settingsVm.groupOrder.collectAsStateWithLifecycle(initialValue = emptyList())
     val groupSortMode = com.aeriotv.android.feature.livetv.GroupSortMode.from(groupSortModeRaw)
@@ -700,6 +701,7 @@ fun ChannelListScreen(
                         palette = palette,
                         showLogo = showChannelLogos,
                         showNumber = showChannelNumbers,
+                        showName = showChannelNames,
                         collectionsMenu = collectionsMenu,
                         onWatchPast = if (channel.hasCatchup) {
                             { prog -> onCatchupResolve(channel, prog) }
@@ -877,6 +879,9 @@ internal fun ChannelRow(
     /** GH #19: when false the channel-number column is omitted, same idea as
      *  showLogo. */
     showNumber: Boolean = true,
+    /** GH #73: when false the channel-name line is omitted from the row; the
+     *  logo and the EPG title below it still identify the channel. */
+    showName: Boolean = true,
     /**
      * Optional leading drag handle, rendered at the very start of the row
      * before the channel number. Only the Favorites tab passes this (to back
@@ -1033,7 +1038,9 @@ internal fun ChannelRow(
                         if (channel.tvgLogo.isNotBlank()) {
                             AsyncImage(
                                 model = channel.tvgLogo,
-                                contentDescription = null,
+                                // GH #73: see the guide rail -- the logo stops
+                                // being decorative once the name is hidden.
+                                contentDescription = if (showName) null else channel.name,
                                 // Fit preserves aspect ratio and centers within
                                 // the 50x32 container, matching iOS SwiftUI's
                                 // default Image.resizable + scaledToFit() pair.
@@ -1073,15 +1080,21 @@ internal fun ChannelRow(
                 // layout pass.
                 Column(modifier = Modifier.weight(1f)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = channel.name,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onBackground,
-                            fontWeight = FontWeight.SemiBold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
+                        // GH #73: the name slot collapses when the toggle is
+                        // off. The catch-up badge beside it does NOT -- it marks
+                        // a capability of the row, not the name, and the rows
+                        // stay uniform because every row loses the same slot.
+                        if (showName) {
+                            Text(
+                                text = channel.name,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onBackground,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false),
+                            )
+                        }
                         // Catch-up badge (Logan 2026-07-20, parity with the
                         // guide rail): a small history clock beside the name
                         // whenever this channel has a replayable archive.

--- a/app/src/main/java/com/aeriotv/android/feature/favorites/FavoritesTabContent.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/favorites/FavoritesTabContent.kt
@@ -76,6 +76,7 @@ fun FavoritesTabContent(
     )
     val showChannelLogos by settingsVm.showChannelLogos.collectAsStateWithLifecycle(initialValue = true)
     val showChannelNumbers by settingsVm.showChannelNumbers.collectAsStateWithLifecycle(initialValue = true)
+    val showChannelNames by settingsVm.showChannelNames.collectAsStateWithLifecycle(initialValue = true)
     val isTv = rememberIsTvDevice()
     val favoriteIds by remember(favorites) {
         derivedStateOf { favorites.asSequence().map { it.channelId }.toHashSet() }
@@ -199,6 +200,7 @@ fun FavoritesTabContent(
                         palette = palette,
                         showLogo = showChannelLogos,
                         showNumber = showChannelNumbers,
+                        showName = showChannelNames,
                         collectionsMenu = collectionsMenu,
                         reorderHandle = {
                             Icon(

--- a/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
@@ -257,6 +257,7 @@ fun GuideScreen(
         initialValue = com.aeriotv.android.core.remote.RemoteControlMap.DEFAULT,
     )
     val showChannelNumbers by settingsVm.showChannelNumbers.collectAsStateWithLifecycle(initialValue = true)
+    val showChannelNames by settingsVm.showChannelNames.collectAsStateWithLifecycle(initialValue = true)
     val multiviewStore = rememberMultiviewStoreHandle()
     // Observe the mini-player session so the guide's Back handler can stand
     // down while the mini is showing (see the BackHandler below for why).
@@ -2368,6 +2369,7 @@ fun GuideScreen(
                     multiviewStore = multiviewStore,
                     showLogo = showChannelLogos,
                     showNumber = showChannelNumbers,
+                    showName = showChannelNames,
                     collectionsMenu = collectionsMenu,
                     onProgrammeWatch = if (channel.hasCatchup) {
                         { prog -> onCatchupResolve(channel, prog) }
@@ -2548,6 +2550,9 @@ private fun ChannelGuideRow(
     showLogo: Boolean = true,
     /** GH #19: when false the channel-number text is omitted from the rail. */
     showNumber: Boolean = true,
+    /** GH #73: when false the channel-name text is omitted from the rail, so a
+     *  logo-only rail hands its width to the programme grid. */
+    showName: Boolean = true,
     collectionsMenu: CollectionsMenuContext? = null,
     /** Catch-up (task #133): non-null when this channel has a replayable
      *  archive; invoked with a PAST programme the user chose to watch. Each
@@ -2702,7 +2707,12 @@ private fun ChannelGuideRow(
                                 .data(channel.tvgLogo)
                                 .size(128, 128)
                                 .build(),
-                            contentDescription = null,
+                            // GH #73: with the name line hidden the logo is
+                            // the only thing identifying this row, so it stops
+                            // being decorative and carries the name for
+                            // TalkBack. With the name shown it stays null, so
+                            // the name is not announced twice.
+                            contentDescription = if (showName) null else channel.name,
                             // GH #25: logos grow with the TV comfort scale like
                             // the row text does - a bigger display scale was
                             // enlarging rows and labels around a fixed 36x24
@@ -2730,19 +2740,23 @@ private fun ChannelGuideRow(
                     }
                     Spacer(Modifier.height(2.dp))
                     }
-                    Text(
-                        text = channel.name,
-                        style = nameStyle,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        // GH #25: at comfort scales the taller row has room for
-                        // a second line, so long channel names wrap instead of
-                        // truncating ("NBC Sports ..." -> full name). Base
-                        // scale keeps the tvOS single-line parity.
-                        maxLines = if (textScale >= 1.25f) 2 else 1,
-                        overflow = TextOverflow.Ellipsis,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    // GH #73: the name line collapses when the toggle is off,
+                    // leaving the logo centred in the rail.
+                    if (showName) {
+                        Text(
+                            text = channel.name,
+                            style = nameStyle,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            // GH #25: at comfort scales the taller row has room for
+                            // a second line, so long channel names wrap instead of
+                            // truncating ("NBC Sports ..." -> full name). Base
+                            // scale keeps the tvOS single-line parity.
+                            maxLines = if (textScale >= 1.25f) 2 else 1,
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
             } else {
                 // iOS EPGGuideView channelLabel (EPGGuideView.swift:3459): a
@@ -2779,7 +2793,7 @@ private fun ChannelGuideRow(
                                     .data(channel.tvgLogo)
                                     .size(128, 128)
                                     .build(),
-                                contentDescription = null,
+                                contentDescription = if (showName) null else channel.name,
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .padding(2.dp),
@@ -2795,15 +2809,18 @@ private fun ChannelGuideRow(
                     }
                     Spacer(Modifier.height(3.dp))
                     }
-                    Text(
-                        text = channel.name,
-                        style = nameStyle,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    // GH #73: same collapse on the phone rail.
+                    if (showName) {
+                        Text(
+                            text = channel.name,
+                            style = nameStyle,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                     // GH #19: the number line collapses when the toggle is off.
                     if (showNumber) {
                         channel.channelNumber?.let { num ->

--- a/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
@@ -110,6 +110,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -2688,54 +2689,68 @@ private fun ChannelGuideRow(
                     // iOS Issue #28: omit the channel logo when "Show Channel
                     // Logos" is off so the name takes the full space.
                     if (showLogo) {
-                    // Landscape logo, tvOS 72x48pt proportional on the 540dp
-                    // canvas -> 36x24dp (matching the channel column's tvOS
-                    // ratios). tvOS parity (rail-match pass): a REAL logo
+                    // The logo SIZES TO THE RAIL rather than sitting at a fixed
+                    // 36x24dp. It claims the rail width and whatever height is
+                    // left after the name line, which is what makes hiding the
+                    // name (GH #73) worth doing: the freed space goes to the
+                    // logo instead of becoming padding. ContentScale.Fit keeps
+                    // the aspect ratio, so a wide landscape logo and a square
+                    // one both letterbox inside the same slot instead of
+                    // stretching.
+                    //
+                    // tvOS parity (rail-match pass) still holds: a REAL logo
                     // floats directly on the rail background like tvOS's
-                    // CachedLogoImage -- no rounded box, no backing fill, no
-                    // inner padding (the dark chip behind every logo was an
-                    // Android-only invention). The boxed treatment survives
-                    // ONLY as the no-logo placeholder, mirroring tvOS's
-                    // guidePlaceholder rounded rect.
-                    if (channel.tvgLogo.isNotBlank()) {
-                        val ctx = androidx.compose.ui.platform.LocalContext.current
-                        // Phase 174: decode at 128x128 px so the downsample to
-                        // display size happens via GPU bilinear rather than
-                        // CPU box-filter. Sharper text/glyphs in logos.
-                        AsyncImage(
-                            model = coil3.request.ImageRequest.Builder(ctx)
-                                .data(channel.tvgLogo)
-                                .size(128, 128)
-                                .build(),
-                            // GH #73: with the name line hidden the logo is
-                            // the only thing identifying this row, so it stops
-                            // being decorative and carries the name for
-                            // TalkBack. With the name shown it stays null, so
-                            // the name is not announced twice.
-                            contentDescription = if (showName) null else channel.name,
-                            // GH #25: logos grow with the TV comfort scale like
-                            // the row text does - a bigger display scale was
-                            // enlarging rows and labels around a fixed 36x24
-                            // logo, which is the thing old-eyes users squint at.
-                            modifier = Modifier.size(
-                                width = 36.dp * textScale,
-                                height = 24.dp * textScale,
-                            ),
-                        )
-                    } else {
-                        Box(
-                            modifier = Modifier
-                                .size(width = 36.dp * textScale, height = 24.dp * textScale)
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = channel.name.take(2).uppercase(),
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                fontWeight = FontWeight.Bold,
+                    // CachedLogoImage -- no rounded box, no backing fill. The
+                    // boxed treatment survives ONLY as the no-logo placeholder,
+                    // mirroring tvOS's guidePlaceholder rounded rect, and that
+                    // chip keeps its compact size because a two-letter monogram
+                    // blown up to fill the rail reads as a bug, not a logo.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            // Breathing room so a logo that fills its slot does
+                            // not touch the rail's divider or the name below.
+                            .padding(horizontal = 2.dp, vertical = 1.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (channel.tvgLogo.isNotBlank()) {
+                            val ctx = androidx.compose.ui.platform.LocalContext.current
+                            // Phase 174: decode above the display size so the
+                            // downsample happens via GPU bilinear rather than
+                            // CPU box-filter. Raised 128 -> 256 with the slot:
+                            // a name-less rail on a 120dp column at density 2
+                            // asks for ~240px, and a 128px decode upscaled into
+                            // that is visibly soft.
+                            AsyncImage(
+                                model = coil3.request.ImageRequest.Builder(ctx)
+                                    .data(channel.tvgLogo)
+                                    .size(256, 256)
+                                    .build(),
+                                // GH #73: with the name line hidden the logo is
+                                // the only thing identifying this row, so it
+                                // stops being decorative and carries the name
+                                // for TalkBack. With the name shown it stays
+                                // null, so the name is not announced twice.
+                                contentDescription = if (showName) null else channel.name,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier.fillMaxSize(),
                             )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .size(width = 36.dp * textScale, height = 24.dp * textScale)
+                                    .clip(RoundedCornerShape(4.dp))
+                                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = channel.name.take(2).uppercase(),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
                         }
                     }
                     Spacer(Modifier.height(2.dp))
@@ -2777,9 +2792,14 @@ private fun ChannelGuideRow(
                     // Android guide honored the toggle before this restyle, so
                     // keep it.)
                     if (showLogo) {
+                    // Same rail-filling treatment as the TV branch above: the
+                    // tile takes the width and the height left over after the
+                    // name + number lines rather than a fixed 40x28dp.
                     Box(
                         modifier = Modifier
-                            .size(width = 40.dp, height = 28.dp)
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .padding(horizontal = 2.dp, vertical = 1.dp)
                             .clip(RoundedCornerShape(4.dp))
                             .background(MaterialTheme.colorScheme.background),
                         contentAlignment = Alignment.Center,
@@ -2791,9 +2811,10 @@ private fun ChannelGuideRow(
                             AsyncImage(
                                 model = coil3.request.ImageRequest.Builder(ctx2)
                                     .data(channel.tvgLogo)
-                                    .size(128, 128)
+                                    .size(256, 256)
                                     .build(),
                                 contentDescription = if (showName) null else channel.name,
+                                contentScale = ContentScale.Fit,
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .padding(2.dp),

--- a/app/src/main/java/com/aeriotv/android/feature/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/settings/AppearanceSettingsScreen.kt
@@ -123,6 +123,7 @@ fun AppearanceSettingsScreen(
     val customAccentHex by viewModel.customAccentHex.collectAsStateWithLifecycle(initialValue = "")
     val showChannelLogos by viewModel.showChannelLogos.collectAsStateWithLifecycle(initialValue = true)
     val showChannelNumbers by viewModel.showChannelNumbers.collectAsStateWithLifecycle(initialValue = true)
+    val showChannelNames by viewModel.showChannelNames.collectAsStateWithLifecycle(initialValue = true)
 
     var pickerTarget by remember { mutableStateOf<ProgramCategory?>(null) }
     var accentPickerOpen by remember { mutableStateOf(false) }
@@ -271,7 +272,7 @@ fun AppearanceSettingsScreen(
                 // its own footer, the palette grid is browse-and-tweak.
                 settingsCard(
                     header = "Channel List",
-                    footer = "Turn logos or numbers off to give long channel names more row width. Applies to the Live TV list and the Guide.",
+                    footer = "Turn logos, numbers or names off to give the rest of the row more width. Applies to the Live TV list and the Guide.",
                 ) {
                     ToggleRow(
                         title = "Show Channel Logos",
@@ -285,6 +286,16 @@ fun AppearanceSettingsScreen(
                         subtitle = "Display each channel's number in the Live TV list and Guide.",
                         checked = showChannelNumbers,
                         onCheckedChange = viewModel::setShowChannelNumbers,
+                    )
+                    DividerRow()
+                    // GH #73. Sits with its siblings rather than in its own card:
+                    // all three answer the same question -- what identifies a
+                    // channel row -- and the shared footer covers them together.
+                    ToggleRow(
+                        title = "Show Channel Name",
+                        subtitle = "Display each channel's name from the M3U or Dispatcharr Server.",
+                        checked = showChannelNames,
+                        onCheckedChange = viewModel::setShowChannelNames,
                     )
                 }
 

--- a/app/src/main/java/com/aeriotv/android/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/settings/SettingsViewModel.kt
@@ -61,6 +61,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { prefs.setShowChannelNumbers(value) }
     }
 
+    val showChannelNames: Flow<Boolean> = prefs.showChannelNames
+    fun setShowChannelNames(value: Boolean) {
+        viewModelScope.launch { prefs.setShowChannelNames(value) }
+    }
+
     // EPG program badges. Per-device-type: the Settings screen passes the
     // current device's isTv so the right value is read/written and synced.
     fun showEpgBadges(isTv: Boolean): Flow<Boolean> = prefs.showEpgBadges(isTv)


### PR DESCRIPTION
Closes #73.

Two commits, both about what the channel rail shows. Happy to split the second into its own PR if you'd rather keep #73 minimal.

## 1. `Show Channel Name` toggle

The Channel List card already lets a user drop the logo or the number from a channel row; the name was the one identifier with no switch. On a rail whose logos are clear artwork the name only repeats what the logo says, and in the guide it spends rail width the programme grid could use.

Adds `ui_show_channel_names` (default **ON**, so existing installs see no change) wired exactly like its two siblings: `AppPreferences` flow + setter → `SettingsViewModel` → a `ToggleRow` in the Channel List card → a `showName` parameter on the shared row composables. It applies everywhere the other two do — the Live TV list, the Favorites tab, and the guide rail, on both the TV and phone layouts.

Settings → Appearance → Channel List:

> **Show Channel Name**
> Display each channel's name from the M3U or Dispatcharr Server.

The card footer becomes "Turn logos, numbers or names off to give the rest of the row more width."

Two details worth calling out:

- **Accessibility.** The rail and list logos pass `contentDescription = null` because the adjacent name announces the row. With the name hidden that leaves nothing identifying the channel, so the logo now carries the name for TalkBack in exactly that case — and stays `null` otherwise, so the name is never announced twice.
- **All three off is allowed.** The row keeps its EPG content and stays focusable and selectable, so nothing force-enables a fallback the user deliberately switched off.

## 2. Logos sized to the rail slot

The rail logo was pinned to 36×24dp on TV (40×28dp on phone) no matter how much room the rail had, so a 120dp column rendered a small mark floating in empty space — most obviously with the new toggle off, where the freed height just became padding.

The logo now takes the rail width and, via `weight(1f)`, whatever height is left after the name line, with `ContentScale.Fit` preserving aspect ratio so a wide landscape mark and a square one letterbox in the same slot instead of stretching. It grows when the name is hidden, shrinks when a long name wraps to two lines at higher comfort scales, and tracks the row height rather than needing its own `textScale` multiplier.

The decode goes 128px → 256px with it: the old size suited a 72×48px draw, while a full rail slot at density 2 asks for ~240px and upscaling a 128px decode into that is visibly soft. The no-logo placeholder keeps its compact chip size deliberately — a two-letter monogram blown up to fill the rail reads as a bug, not a logo.

## Verification

On an **onn. Streaming Device 4K pro** (Google TV, Android 14 / API 34), guide populated from Dispatcharr with Schedules Direct EPG:

| | Result |
|---|---|
| Toggle off | Names disappear from the guide rail, logos remain centred and expand to fill the cell |
| Toggle on | Names return; logo shrinks back to share the cell |
| Round trip | Setting survives being written and re-read through the DataStore |
| Long name (`Los Angeles Dodgers`) | Wraps to two lines at the user's comfort scale, logo takes the smaller remainder — no clipping |
| Default (fresh install) | ON, so nothing changes for existing users |

Phone/tablet paths are the same code with the same parameters; the phone rail branch got the identical treatment.

## Not included

This branch is cut from `main` and deliberately does **not** contain the #72 guide-row-height fix (PR #74), so the two can be reviewed and merged independently. They touch different parts of `GuideScreen.kt` and do not conflict.
