### PR TITLE
Guide perf: ~4x faster D-pad navigation on low-end Android TV

### DIFF
--- a/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
@@ -3307,6 +3307,34 @@ private fun ProgrammeCell(
         }
     }
     var focused by remember { mutableStateOf(false) }
+
+    // Progressive detail. A cell composed WHILE the user is navigating renders
+    // its title only, then fills in the sub-title / description / time+badges
+    // once movement settles. Composing those lines is the bulk of a cell's
+    // cost, and during a held D-pad the rows they land on are being scrolled
+    // past unread -- this is what a Leanback guide gets for free by binding a
+    // recycled view lazily.
+    //
+    // The initial read is a PLAIN field read (see lastFocusMoveAtMs), so no
+    // cell subscribes to focus moves, and cells already on screen with their
+    // detail drawn are never revisited -- only the ones being composed right
+    // now start bare. The cost of settling is therefore proportional to what
+    // was just composed, not to everything on screen.
+    var showDetail by remember {
+        mutableStateOf(
+            android.os.SystemClock.uptimeMillis() - guideNav.lastFocusMoveAtMs >= GUIDE_DETAIL_SETTLE_MS
+        )
+    }
+    if (!showDetail) {
+        LaunchedEffect(Unit) {
+            while (
+                android.os.SystemClock.uptimeMillis() - guideNav.lastFocusMoveAtMs < GUIDE_DETAIL_SETTLE_MS
+            ) {
+                delay(GUIDE_DETAIL_POLL_MS)
+            }
+            showDetail = true
+        }
+    }
     val cellDensity = androidx.compose.ui.platform.LocalDensity.current
     // Short time-range label ("7:00 - 7:30"), shown on the TV guide cell beneath
     // the title to match the tvOS Emby-style cell (title + time range).
@@ -3686,7 +3714,7 @@ private fun ProgrammeCell(
                 // GH #34: the XMLTV <sub-title> (episode / sports-match name,
                 // e.g. "Team A vs Team B") is what distinguishes back-to-back
                 // programmes with the same generic title; surface it in the cell.
-                programme.subTitle?.takeIf { it.isNotBlank() }?.let { sub ->
+                programme.subTitle?.takeIf { showDetail && it.isNotBlank() }?.let { sub ->
                     Text(
                         text = sub,
                         style = MaterialTheme.typography.labelSmall,
@@ -3697,7 +3725,7 @@ private fun ProgrammeCell(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                if (programme.description.isNotBlank()) {
+                if (showDetail && programme.description.isNotBlank()) {
                     Text(
                         text = programme.description,
                         style = MaterialTheme.typography.labelSmall,
@@ -3707,7 +3735,7 @@ private fun ProgrammeCell(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                if (!programme.isPlaceholder) {
+                if (showDetail && !programme.isPlaceholder) {
                     // Time range plus the season/episode pill and badge flags,
                     // folded onto one line so the height-limited TV cell does
                     // not gain a row. Trailing badges clip first on narrow cells.
@@ -3779,7 +3807,7 @@ private fun ProgrammeCell(
                     }
                 }
                 // GH #34: surface the XMLTV <sub-title> (match/episode name).
-                programme.subTitle?.takeIf { it.isNotBlank() }?.let { sub ->
+                programme.subTitle?.takeIf { showDetail && it.isNotBlank() }?.let { sub ->
                     Text(
                         text = sub,
                         style = MaterialTheme.typography.labelSmall,
@@ -3804,7 +3832,7 @@ private fun ProgrammeCell(
                 }
                 val hasBadgeRow = flags.isNotEmpty() || seLabel != null
 
-                if (programme.description.isNotBlank()) {
+                if (showDetail && programme.description.isNotBlank()) {
                     Text(
                         text = programme.description,
                         style = MaterialTheme.typography.labelSmall,
@@ -3831,7 +3859,7 @@ private fun ProgrammeCell(
                 }
                 // Badges sit BELOW the title and description so the cell reads
                 // cleanly top-down instead of a busy middle row.
-                if (hasBadgeRow) {
+                if (showDetail && hasBadgeRow) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(3.dp),
@@ -3931,6 +3959,15 @@ private const val GUIDE_VIEWPORT_PAD_MS = 90L * 60_000L
  *  who stopped to read can start moving horizontally. */
 private const val GUIDE_HALO_SETTLE_MS = 180L
 
+/** How long after the last focus move a cell waits before filling in its detail
+ *  lines. Comfortably longer than the remote's key-repeat interval so a held
+ *  D-pad never triggers a fill mid-burst, and short enough to land within a
+ *  frame or two of the user stopping. */
+private const val GUIDE_DETAIL_SETTLE_MS = 140L
+
+/** Poll step while a bare cell waits for movement to settle. */
+private const val GUIDE_DETAIL_POLL_MS = 40L
+
 /** Convert a millisecond span to its dp width on the (already scaled) time axis. */
 private fun msToDp(ms: Long, hourWidth: androidx.compose.ui.unit.Dp): androidx.compose.ui.unit.Dp =
     (hourWidth.value * (ms.toFloat() / MS_PER_HOUR_F)).dp
@@ -3979,6 +4016,13 @@ private class GuideVerticalNavState {
      *  observable state -- only the key handler reads/writes it to throttle the
      *  held-key fast-scroll to [HOLD_SCROLL_MIN_INTERVAL_MS]. */
     var lastVerticalMoveAtMs = 0L
+
+    /** uptimeMillis of the last focus move in EITHER direction. Plain field, not
+     *  observable state, and deliberately so: cells read it once at composition
+     *  to decide whether to defer their detail lines, and a snapshot-backed read
+     *  there would subscribe every composed cell to every focus move -- exactly
+     *  the cost the deferral exists to avoid. */
+    var lastFocusMoveAtMs = 0L
 
     /** True from [beginVerticalMove] until the move coroutine settles. Lets the
      *  key handler keep stepping channel-by-channel on rapid / long-press UP
@@ -4155,6 +4199,7 @@ private class GuideVerticalNavState {
     /** Called by a cell when it gains focus. Records which channel row owns
      *  focus and the time column the user is in. */
     fun onCellFocused(channelIndex: Int, cellStartMs: Long) {
+        lastFocusMoveAtMs = android.os.SystemClock.uptimeMillis()
         focusedChannelIndex = channelIndex
         lastFocusedChannelIndex = channelIndex
         // Raw column of the cell that actually holds focus (never clamped forward),

--- a/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/livetv/GuideScreen.kt
@@ -97,6 +97,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -2584,6 +2585,32 @@ private fun ChannelGuideRow(
         derivedStateOf { channelIndex == guideNav.lastFocusedChannelIndex }
     }
 
+    // Perf: the focused row's halo (below) is DEFERRED until focus rests here.
+    //
+    // The halo composes ~5x the padded window so a horizontal page-jump always
+    // lands on a live cell. Paying it the instant focus arrives made every
+    // vertical press compose that whole batch on the new row and dispose it on
+    // the old one -- measured on an onn 4K pro (release, 20 scripted Downs):
+    // 750ms median frame, 74% janky, with 160ms mean / 486ms worst spent in
+    // Compose+layout+display-list on the UI thread. A held Down is a burst of
+    // presses, so the halo was rebuilt for rows the user is only passing
+    // THROUGH.
+    //
+    // Nothing needs it mid-burst: the halo guards horizontal moves, which can
+    // only start once the user stops moving vertically, and the composed pad
+    // (a full viewport each side) already covers a page-jump's 0.85-viewport
+    // stride on its own. So rows keep the plain viewport clip while focus is
+    // travelling, and the halo builds on the idle frame after it settles.
+    var haloActive by remember(channelIndex) { mutableStateOf(false) }
+    LaunchedEffect(rowIsFocused) {
+        if (!rowIsFocused) {
+            haloActive = false
+        } else {
+            delay(GUIDE_HALO_SETTLE_MS)
+            haloActive = true
+        }
+    }
+
     // Compact rail sizing. On TV we keep it tight (narrow rail, small logo) so
     // more channels fit; legibility comes from the name/cell text, not bulk.
     // The number column is TV-only: the phone cell stacks its number UNDER the
@@ -3012,7 +3039,9 @@ private fun ChannelGuideRow(
                     // rowIsFocused is hoisted to the row body as a derivedStateOf
                     // (see above) so reading it here doesn't subscribe this row to
                     // every lastFocusedChannelIndex change.
-                    if (!rowIsFocused &&
+                    // haloActive, not rowIsFocused: a row focus is merely PASSING
+                    // through stays viewport-clipped like any other row.
+                    if (!haloActive &&
                         (rawEnd <= visibleStartMs || rawStart >= visibleEndMs)
                     ) return@forEachIndexed
                     // Task #188: BOUND the focused-row exception. Composing the
@@ -3025,7 +3054,7 @@ private fun ChannelGuideRow(
                     // exception exists for cannot reach cells 2+ windows away,
                     // because the column snap and retarget logic always pull
                     // focus back toward the viewport first.
-                    if (rowIsFocused) {
+                    if (haloActive) {
                         val haloMs = (visibleEndMs - visibleStartMs) * 2
                         if (rawEnd <= visibleStartMs - haloMs ||
                             rawStart >= visibleEndMs + haloMs
@@ -3281,7 +3310,10 @@ private fun ProgrammeCell(
     val cellDensity = androidx.compose.ui.platform.LocalDensity.current
     // Short time-range label ("7:00 - 7:30"), shown on the TV guide cell beneath
     // the title to match the tvOS Emby-style cell (title + time range).
-    val cellTimeFmt = remember { SimpleDateFormat("h:mm", Locale.getDefault()) }
+    // Perf: one formatter for the whole guide instead of one allocated (and
+    // remembered, and GC'd) per cell. SimpleDateFormat is not thread-safe, but
+    // every use here is on the composition thread.
+    val cellTimeFmt = guideCellTimeFormat
     val timeRange = remember(programme.startMillis, programme.endMillis) {
         "${cellTimeFmt.format(java.util.Date(programme.startMillis))} - " +
             cellTimeFmt.format(java.util.Date(programme.endMillis))
@@ -3386,13 +3418,30 @@ private fun ProgrammeCell(
             // frame, which made D-pad navigation laggy. The cheap border + bg
             // highlight below is the guide's focus cue; the springy grow lives
             // only on the sparse surfaces (nav pills, On Demand posters, rows).
-            .clip(cellShape)
-            .background(cellBg)
-            .then(
-                if (cellBorderWidth > 0.dp)
-                    Modifier.border(cellBorderWidth, cellBorderColor, cellShape)
-                else Modifier,
-            )
+            // Perf: fill + focus ring drawn in ONE node instead of the
+            // clip -> background -> border chain. Three modifier nodes per cell
+            // (one of them a clip, which forces its own render layer) x ~126
+            // composed cells was ~2ms of display-list recording per cell on
+            // every scroll frame. drawBehind paints the identical rounded fill
+            // and inset ring with no layer and no clip.
+            .drawBehind {
+                val r = if (focused) 4.dp.toPx() else 0f
+                val corner = androidx.compose.ui.geometry.CornerRadius(r, r)
+                drawRoundRect(color = cellBg, cornerRadius = corner)
+                val bw = cellBorderWidth.toPx()
+                if (bw > 0f) {
+                    drawRoundRect(
+                        color = cellBorderColor,
+                        topLeft = androidx.compose.ui.geometry.Offset(bw / 2f, bw / 2f),
+                        size = androidx.compose.ui.geometry.Size(
+                            (size.width - bw).coerceAtLeast(0f),
+                            (size.height - bw).coerceAtLeast(0f),
+                        ),
+                        cornerRadius = corner,
+                        style = androidx.compose.ui.graphics.drawscope.Stroke(width = bw),
+                    )
+                }
+            }
             .onFocusChanged {
                 focused = it.isFocused
                 // Record which channel row + time column owns focus so the
@@ -3414,6 +3463,13 @@ private fun ProgrammeCell(
                 // can land back on this cell and would otherwise start playback.
                 onClick = menuGuard.wrap(onPlay),
                 onLongClick = { menuOpen = true; menuGuard.arm() },
+                // Perf: no ripple. Focus is already conveyed by the cell fill +
+                // ring drawn above, and an indication node per cell costs
+                // composition on every cell the guide builds. Phone keeps the
+                // same behaviour minus the ripple wash, which the flat Emby-style
+                // cell never really showed anyway.
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
             )
             // tvOS programCell uses .padding(.horizontal, 8) / .padding(.vertical, 6)
             // on a 110pt row -> proportional 4dp/3dp on the 55dp Android-TV row.
@@ -3868,6 +3924,12 @@ private const val SIDEBAR_HOLD_OPEN_MS = 320L
  *  the focus search found no horizontal neighbour. Pairs with the grid's
  *  L/R focus-exit cancel so horizontal nav never escapes to the chrome. */
 private const val GUIDE_VIEWPORT_PAD_MS = 90L * 60_000L
+
+/** How long focus must REST on a row before it pays for the focus halo. Long
+ *  enough that a held D-pad Down (repeat rate ~60-120ms on the onn remote)
+ *  never triggers one mid-burst, short enough to be built well before a user
+ *  who stopped to read can start moving horizontally. */
+private const val GUIDE_HALO_SETTLE_MS = 180L
 
 /** Convert a millisecond span to its dp width on the (already scaled) time axis. */
 private fun msToDp(ms: Long, hourWidth: androidx.compose.ui.unit.Dp): androidx.compose.ui.unit.Dp =
@@ -4371,4 +4433,15 @@ private class GuideLeadingEdgeBringIntoViewSpec(
         // the timeline days into catch-up history. Refuse instead.
         return if (abs(distance) > containerSize) 0f else distance
     }
+}
+
+
+/** Shared "h:mm" formatter for guide cells. One instance for the process rather
+ *  than one allocated, remembered and GC'd per composed cell -- the guide builds
+ *  and disposes these by the dozen on every D-pad press. SimpleDateFormat is not
+ *  thread-safe; every use is on the composition (main) thread. Locale is read
+ *  once, so a locale change takes effect on the next process start, which is
+ *  what the rest of this screen's static formatters already assume. */
+private val guideCellTimeFormat: SimpleDateFormat by lazy(LazyThreadSafetyMode.NONE) {
+    SimpleDateFormat("h:mm", Locale.getDefault())
 }


### PR DESCRIPTION
D-pad navigation in the guide is ~4x faster on a low-end Android TV box. Two commits, both behind measurements taken on the device.

## Measurements

onn. Streaming Device 4K pro (Google TV, Android 14 / API 34, `armeabi-v7a`, 1080p60), **release** build, Dispatcharr + Schedules Direct EPG, 438 channels. 20 scripted D-pad presses per run, three runs, `dumpsys gfxinfo`.

| | DOWN median frame | DOWN p90 | frames per 20 presses |
|---|---|---|---|
| `main` | 450-500 ms | 750 ms | 23-25 |
| + commit 1 | 150-200 ms | ~430 ms | 28 |
| + commit 2 (this branch) | **113-125 ms** | **150-200 ms** | 26-27 |

Horizontal stepping on this branch measures 150 ms median / 300 ms p90. There is deliberately no before/after for the horizontal axis: the only baseline horizontal run I have was taken while post-install compilation was still running, and is not comparable (see the methodology note at the bottom).

## Where the time actually goes

`gfxinfo framestats` phase breakdown during vertical navigation, before any change:

| phase | mean | worst |
|---|---|---|
| input queue (backlog from prior slow frames) | 79 ms | 176 ms |
| traversal | 0.1 ms | 0.1 ms |
| **draw record — Compose recompose + layout + display list, UI thread** | **160 ms** | **486 ms** |
| GPU | 18 ms | 20 ms |

GPU was never the constraint, so overdraw and layer count were red herrings. Temporary counters put the cause precisely: **10 presses composed ~450 cells across 14 rows, with only 2 visible-window changes** — so it was not window thrash either. It was ~45 cells composed per press at ~9 ms each, because a focus flip recomposes the whole row and re-runs its cell loop.

## Commit 1 — cheaper cells, deferred halo

- **The focused row's halo is deferred until focus rests on the row.** It composes ~5x the padded window so a horizontal page-jump always lands on a live cell, and it was being rebuilt on every press for rows the user is only passing through. Nothing needs it mid-burst: it guards horizontal moves, which cannot begin until vertical movement stops, and the composed pad (a full viewport per side) already covers a page-jump's 0.85-viewport stride on its own.
- **Cell fill + focus ring draw in one `drawBehind`** instead of `clip` → `background` → `border`. Three modifier nodes per cell, one of them a clip forcing its own render layer, times ~126 composed cells, re-recorded on every scroll frame. Pixel-verified identical afterwards: the focus ring measures 8 px of pure white at density 2 = the same 4 dp.
- **No ripple/indication on the cell, and one shared `h:mm` formatter** instead of a `SimpleDateFormat` allocated and remembered per cell. Focus is conveyed by the cell fill and ring; an indication node per cell is pure composition cost on a surface that builds cells by the dozen per press.

## Commit 2 — defer cell detail while the D-pad is moving

A cell composed *while* the user is navigating renders its title only, then fills in the sub-title / description / time+badges row once movement settles (140 ms). Composing those lines is most of a cell's cost, and during a held D-pad the rows carrying them are being scrolled past unread. This is what a Leanback guide gets for free by binding a recycled view lazily.

Two properties keep this a real saving rather than a moved one:

- The settle timestamp is a **plain field, not snapshot state**, so no cell subscribes to focus moves. A snapshot read there would recompose every composed cell twice per burst — exactly the cost being avoided.
- Cells already on screen with their detail drawn are never revisited; only cells being composed *right now* start bare. Settling therefore costs in proportion to what was just composed, not to everything on screen.

**Tradeoff, deliberately accepted:** detail visibly pops in ~140 ms after you stop moving. Verified by screenshot — bare mid-burst, complete once settled. `GUIDE_DETAIL_SETTLE_MS` is one constant; happy to expose it as a setting, or raise/lower it, if you'd rather tune the feel.

## Two further levers, measured and rejected

Both were implemented and benchmarked on top of this branch, then dropped:

| lever | DOWN median | verdict |
|---|---|---|
| Drop the focus halo entirely | 117-150 ms | **No gain** (within noise of 113-125 ms), and it would take the documented focus-orphan risk for nothing. |
| Composed pad 1.0 → 0.4 viewport | 97-117 ms | ~15% on vertical, but horizontal stayed 150-200 ms — it hands back on one axis what it saves on the other, and re-opens the blank-cell regression Task #190 added the pad to fix. |

A fast pan on the 0.4-viewport build showed no blank cells and focus stayed in the grid, but `adb` key injection is slower than a real held remote, so that is not a clearance — which is part of why it is not proposed here.

## What this does not do

At ~113 ms/press this is still ~7x over a 16.7 ms frame budget. The remaining cost is composing ~18 cells per newly revealed row. Closing that needs either a structurally cheaper `ProgrammeCell` (currently a Column of Row + up to 3 Texts + badge Row + progress Box) or view reuse across rows, which Compose will not do inside a manually laid-out strip. Both are far more invasive than anything here.

## Methodology note for anyone re-running this

Measure only after post-install `dex2oat`/ProfileInstaller work has finished. Runs taken immediately after an install read **3-5x worse** and are not comparable between builds — early in this investigation they made one change look like a regression when it was an improvement. Every number above comes from: install → launch → 45 s settle → two warmup passes → three measured runs.
