### PR TITLE
TV remote: honor a custom LEFT/RIGHT map on bare fullscreen video

### DIFF
--- a/app/src/main/java/com/aeriotv/android/MainActivity.kt
+++ b/app/src/main/java/com/aeriotv/android/MainActivity.kt
@@ -98,6 +98,21 @@ class MainActivity : ComponentActivity() {
      *  release doesn't also fire the short action. */
     private var dpadVertLongFired = false
 
+    /** Same as [dpadVertLongFired], for the LEFT/RIGHT split. */
+    private var dpadHorizLongFired = false
+
+    /** True once a captured D-pad LEFT/RIGHT ACTION_DOWN has been seen, so a
+     *  stray ACTION_UP (dpadHorizontalCaptured can flip between the DOWN and
+     *  the UP of the same press) doesn't fire the short action on its own. */
+    private var dpadHorizDownSeen = false
+
+    /** uptimeMillis of the last dispatched horizontal short action while a
+     *  key auto-repeats, so a held LEFT/RIGHT with no long slot (e.g. the
+     *  legacy seek map during live-rewind buffering) can't fire faster than
+     *  DPAD_HORIZ_REPEAT_MS - unthrottled repeats would drive scrubStep's
+     *  acceleration to its mult=12 ceiling (PlayerScreen.kt) within a second. */
+    private var dpadHorizLastSeekAt = 0L
+
     /**
      * Audit task #22 mini-player resume. The Google TV Streamer remote has
      * no dedicated play/pause key, so we repurpose a double-press of D-pad
@@ -253,6 +268,72 @@ class MainActivity : ComponentActivity() {
                     KeyEvent.ACTION_UP -> {
                         if (!dpadVertLongFired) dispatchPlayerAction(shortAction)
                         dpadVertLongFired = false
+                        return true
+                    }
+                }
+            }
+        }
+        // Live LEFT/RIGHT: mirrors the UP/DOWN branch above so a remapped
+        // LEFT_SHORT/RIGHT_SHORT (or the default map's channel-list / last-
+        // channel / minimize / program-info slots) wins over the chrome pill
+        // row the same way surf keys do, instead of falling through to
+        // Compose focus and getting eaten by that row (see
+        // ExoWindowState.dpadHorizontalCaptured).
+        if (isTelevisionDevice() &&
+            (event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+                event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) &&
+            exoWindowState.mode.value == ExoWindowState.Mode.Fullscreen
+        ) {
+            val isLeft = event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT
+            val shortAction = remoteMap.playerAction(
+                if (isLeft) com.aeriotv.android.core.remote.RemoteSlot.LEFT_SHORT
+                else com.aeriotv.android.core.remote.RemoteSlot.RIGHT_SHORT,
+            )
+            val longAction = remoteMap.playerAction(
+                if (isLeft) com.aeriotv.android.core.remote.RemoteSlot.LEFT_LONG
+                else com.aeriotv.android.core.remote.RemoteSlot.RIGHT_LONG,
+            )
+            if (!exoWindowState.dpadHorizontalCaptured) {
+                // Chrome / a menu / an overlay owns horizontal focus right
+                // now (or PlayerScreen's own catch-up block does): hand the
+                // keys to Compose untouched.
+            } else if (longAction == com.aeriotv.android.core.remote.PlayerRemoteAction.NONE) {
+                if (event.action == KeyEvent.ACTION_DOWN) {
+                    if (shortAction == com.aeriotv.android.core.remote.PlayerRemoteAction.NONE) {
+                        // Nothing mapped: fall through every time, exactly
+                        // like the legacy unmapped-key chrome nav path.
+                    } else {
+                        val now = android.os.SystemClock.uptimeMillis()
+                        if (event.repeatCount == 0 ||
+                            now - dpadHorizLastSeekAt >= DPAD_HORIZ_REPEAT_MS
+                        ) {
+                            dpadHorizLastSeekAt = now
+                            if (dispatchPlayerAction(shortAction)) return true
+                        } else {
+                            return true // rate-limited repeat: swallow, don't re-dispatch yet
+                        }
+                    }
+                }
+            } else {
+                when (event.action) {
+                    KeyEvent.ACTION_DOWN -> {
+                        if (event.repeatCount == 0) {
+                            dpadHorizLongFired = false
+                            dpadHorizDownSeen = true
+                        } else if (!dpadHorizLongFired &&
+                            (event.isLongPress || event.repeatCount >= MINI_CLOSE_HOLD_REPEAT)
+                        ) {
+                            dpadHorizLongFired = true
+                            dispatchPlayerAction(longAction)
+                        }
+                        return true
+                    }
+                    KeyEvent.ACTION_UP -> {
+                        if (dpadHorizDownSeen && !dpadHorizLongFired) {
+                            dispatchPlayerAction(shortAction)
+                        }
+                        dpadHorizLongFired = false
+                        dpadHorizDownSeen = false
                         return true
                     }
                 }
@@ -1081,5 +1162,11 @@ class MainActivity : ComponentActivity() {
          *  pin first; this bounds a missed release. Mirrors the guide hold-Left
          *  pin's 2.5s safety timeout. */
         const val RIGHT_HOLD_PIN_MS = 2_500L
+
+        /** Floor (ms) between dispatched horizontal short actions while a
+         *  key auto-repeats with no long slot mapped. Mirrors scrubStep's own
+         *  250ms held-scrub throttle (PlayerScreen.kt) so a map that lands a
+         *  seek action on LEFT_SHORT/RIGHT_SHORT can't outrun it. */
+        const val DPAD_HORIZ_REPEAT_MS = 250L
     }
 }

--- a/app/src/main/java/com/aeriotv/android/feature/player/ExoWindowState.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/player/ExoWindowState.kt
@@ -76,6 +76,28 @@ class ExoWindowState @Inject constructor() {
     @Volatile var dpadVerticalCaptured: Boolean = true
 
     /**
+     * Whether the fullscreen player currently OWNS D-pad LEFT/RIGHT
+     * (short/long slot actions, or - unmapped to a slot - live-rewind /
+     * catch-up scrubbing). Same purpose as [dpadVerticalCaptured] -
+     * PlayerScreen publishes false while chrome, a menu/sheet, the
+     * Recently Watched overlay, or the Channels overlay is up, so
+     * MainActivity's split hands the keys to Compose focus traversal
+     * instead. Two deliberate differences from the vertical predicate,
+     * both load-bearing:
+     *  - it does NOT release on the scrub HUD - that HUD is up exactly
+     *    because a hold is scrubbing the live-rewind buffer, and LEFT/
+     *    RIGHT must keep driving that scrub rather than handing off to
+     *    Compose focus mid-hold;
+     *  - it additionally excludes catch-up mode: PlayerScreen's own
+     *    LEFT/RIGHT block always scrubs the programme during catch-up
+     *    regardless of the map, and suppresses CHANNEL_LIST there too.
+     *    Publishing false for the whole of catch-up leaves that path
+     *    bit-for-bit unchanged.
+     * Defaults true (bare fullscreen video = mapped slot keys).
+     */
+    @Volatile var dpadHorizontalCaptured: Boolean = true
+
+    /**
      * Remote Control phase A2: session-scoped last-channel zap memory
      * (`lastChannel` zap-back, a 1-deep stack). [recordTune] is called
      * on every successful live tune with the channel's stable id; it

--- a/app/src/main/java/com/aeriotv/android/feature/player/PlayerScreen.kt
+++ b/app/src/main/java/com/aeriotv/android/feature/player/PlayerScreen.kt
@@ -1372,7 +1372,14 @@ fun PlayerScreen(
                     }
                 }
                 // Remote Control: LEFT/RIGHT on bare fullscreen video
-                // (chrome hidden, no overlay). One unified block, two modes:
+                // (chrome hidden, no overlay). MainActivity.dispatchKeyEvent
+                // now handles these first for both the default and a custom
+                // map (see exoWindowState.dpadHorizontalCaptured, mirroring
+                // the split below), so ordinary fullscreen never reaches this
+                // block anymore. It remains the path during catch-up, which
+                // dpadHorizontalCaptured deliberately always releases, and in
+                // the edge case where chrome is hidden but a menu/sheet is
+                // open. One unified block, two modes:
                 //  - transport (rewind buffering with a SEEK-mapped slot, or
                 //    ANY catch-up replay): every ACTION_DOWN scrubs, exactly
                 //    the pre-initiative behavior - held keys auto-repeat the
@@ -1668,9 +1675,20 @@ fun PlayerScreen(
         exoWindowState.dpadVerticalCaptured = !chromeVisible && !scrubHudVisible &&
             scrubTargetWallMs == null && !recentsOverlayVisible &&
             !channelListVisible && !interactionLocked
+        // Unlike vertical, horizontal does NOT release on the scrub HUD -
+        // that HUD is up exactly when a hold is scrubbing, and LEFT/RIGHT
+        // must keep driving the scrub rather than handing off to Compose
+        // focus mid-hold. It additionally excludes catch-up mode, where
+        // this screen's own LEFT/RIGHT block always scrubs regardless of
+        // the map (see ExoWindowState.dpadHorizontalCaptured KDoc).
+        exoWindowState.dpadHorizontalCaptured = !chromeVisible && !recentsOverlayVisible &&
+            !channelListVisible && !interactionLocked && !isCatchupMode
     }
     DisposableEffect(exoWindowState) {
-        onDispose { exoWindowState.dpadVerticalCaptured = true }
+        onDispose {
+            exoWindowState.dpadVerticalCaptured = true
+            exoWindowState.dpadHorizontalCaptured = true
+        }
     }
     // streamUnavailable is a KEY (not just a guard): when it clears on
     // recovery, this effect must re-fire so the chrome that was pinned open


### PR DESCRIPTION
## Summary

On Android TV, remapping D-pad LEFT/RIGHT under Settings > Remote Control had no effect on bare fullscreen video. `MainActivity.dispatchKeyEvent` only performed the short/long split for the default map; a custom map fell through to `PlayerScreen`, which still ran the default channel-list / last-channel handling. Mapping LEFT short = Seek back and RIGHT short = Seek forward therefore looked like a dead setting.

This mirrors the existing vertical (UP/DOWN) split for the horizontal axis:

- `ExoWindowState.dpadHorizontalCaptured` (new, default `true`) is published by `PlayerScreen` while bare fullscreen video owns LEFT/RIGHT. It goes `false` while chrome, a menu/sheet, the Recently Watched overlay, or the Channels overlay is up, and for the whole of catch-up mode. Unlike the vertical flag it does **not** release on the scrub HUD, so a held key keeps driving a live-rewind scrub.
- `MainActivity` now resolves the LEFT/RIGHT short and long slots from the current map. With a long slot mapped, the short action fires on ACTION_UP and the long action on the first long-press repeat. With no long slot (e.g. the legacy seek map) the short action fires on ACTION_DOWN, throttled to one dispatch per 250 ms while the key auto-repeats.
- When the flag is `false` the keys pass through to Compose focus traversal exactly as before. Catch-up scrubbing is unchanged.

## Tested

Android TV emulator (API 30, x86), TV remote via D-pad.

Default map, bare fullscreen video:
- LEFT short opens the Channels overlay; LEFT long minimizes to the guide with the mini-player.
- RIGHT short zaps to the last channel; RIGHT long shows program info.
- RIGHT with the Channels overlay open dismisses it (overlay's own handler); RIGHT with chrome visible moves focus between chrome buttons, no zap.

Custom map (LEFT short = Seek back, RIGHT short = Seek forward, holds unchanged), Live Rewind on, raw MPEG-TS channel:
- Each LEFT short press seeks back with the scrub HUD showing; each RIGHT short press seeks forward, and reaching the head returns to live.
- RIGHT long still shows program info without seeking.

Unit tests under `app/src/test` pass.

## Not tested

Phone / tablet (touch path is untouched), Cast, catch-up mode with a custom map, and physical Android TV hardware (Shield, Chromecast with Google TV). Note that seek actions only do something while Live Rewind is buffering, which requires a raw MPEG-TS stream; on HLS channels a seek-mapped key is a no-op both before and after this change.
